### PR TITLE
feat: add config template and defaults for sqlite-only store

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,10 @@ nim_waku_p2p_max_connections: 150
 # maximum number of stored historical messages
 nim_waku_store_capacity: 10000
 
+# SQLite store
+nim_waku_sqlite_store: false
+nim_waku_sqlite_retention_time: 30.days.seconds
+
 # RLN Relay topic
 #nim_waku_rln_relay_content_topic: ~
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,7 +45,7 @@ nim_waku_store_capacity: 10000
 
 # SQLite store
 nim_waku_sqlite_store: false
-nim_waku_sqlite_retention_time: 30.days.seconds
+nim_waku_sqlite_retention_time: '7.days.seconds'
 
 # RLN Relay topic
 #nim_waku_rln_relay_content_topic: ~

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -50,8 +50,10 @@ services:
       --max-connections={{ nim_waku_p2p_max_connections }}
       --store-capacity={{ nim_waku_store_capacity }}
       --dns4-domain-name={{ nim_waku_dns4_domain_name }}
-      --sqlite-store={{ nim_waku_sqlite_store }}
+{% if nim_waku_sqlite_store %}
+      --sqlite-store=true
       --sqlite-retention-time={{ nim_waku_sqlite_retention_time }}
+{% endif %}
 {% if "rln-relay" in nim_waku_protocols_enabled %}
       --rln-relay-content-topic={{ nim_waku_rln_relay_content_topic }}
 {% endif -%}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -50,6 +50,8 @@ services:
       --max-connections={{ nim_waku_p2p_max_connections }}
       --store-capacity={{ nim_waku_store_capacity }}
       --dns4-domain-name={{ nim_waku_dns4_domain_name }}
+      --sqlite-store={{ nim_waku_sqlite_store }}
+      --sqlite-retention-time={{ nim_waku_sqlite_retention_time }}
 {% if "rln-relay" in nim_waku_protocols_enabled %}
       --rln-relay-content-topic={{ nim_waku_rln_relay_content_topic }}
 {% endif -%}


### PR DESCRIPTION
This PR adds the config template and defaults for the SQLite store feature, available in nwaku `v0.10` and above.

Subsequent PRs will follow in infra-nim-waku and infra-status for fleet specific configuration.

cc @richard-ramos @kaiserd