### PR TITLE
feat: allow enabling DNS discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ nim_waku_websocket_ssl_key: '/etc/letsencrypt/live/{{ nim_waku_websocket_domain 
 ```
 In this case [LetsEncrypt](https://letsencrypt.org/) is used, but any other certificate would work as long ass the full chain is used.
 
+DNS-based discovery can be enabled to bootstrap a node's connections to a list of existing peers at the configured domain.
+The configured domain URL should be in the format 'enrtree://<key>@<fqdn>', for example:
+```yaml
+nim_waku_dns_disc_enabled: true
+nim_waku_dns_disc_url: 'enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im'
+```
+
 # Usage
 
 You can re-create containers on the host using:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ nim_waku_discovery_enabled: false
 
 # DNS Discovery
 nim_waku_dns_disc_enabled: false
+# nim_waku_dns_disc_url: 'enrtree://AOFTICU2XWDULNLZGRMQS4RIZPAZEHYMV4FYHAPW563HNRAOERP7C@test.waku.nodes.status.im'
 
 # Discovery V5
 nim_waku_disc_v5_enabled: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,9 @@ nim_waku_log_level: 'info'
 # experimental discovery support
 nim_waku_discovery_enabled: false
 
+# DNS Discovery
+nim_waku_dns_disc_enabled: false
+
 # Discovery V5
 nim_waku_disc_v5_enabled: false
 nim_waku_disc_v5_enr_auto_update: false

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -65,6 +65,10 @@ services:
       --websocket-secure-cert-path={{ nim_waku_websocket_ssl_cert | mandatory }}
 {% endif %}
 {% endif %}
+{% if nim_waku_dns_disc_enabled %}
+      --dns-discovery=true
+      --dns-discovery-url={{ nim_waku_dns_disc_url }}
+{% endif %}
 {% if nim_waku_disc_v5_enabled %}
       --discv5-discovery=true
       --discv5-udp-port={{ nim_waku_disc_v5_port }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -67,7 +67,7 @@ services:
 {% endif %}
 {% if nim_waku_dns_disc_enabled %}
       --dns-discovery=true
-      --dns-discovery-url={{ nim_waku_dns_disc_url }}
+      --dns-discovery-url={{ nim_waku_dns_disc_url | mandatory }}
 {% endif %}
 {% if nim_waku_disc_v5_enabled %}
       --discv5-discovery=true


### PR DESCRIPTION
PR allows for DNS discovery to be enabled in the nim-waku role.

A subsequent PR in [infra-nim-waku](https://github.com/status-im/infra-nim-waku) will enable DNS discovery for the `wakuv2.test` fleet.

UPDATE: related PR created at https://github.com/status-im/infra-nim-waku/pull/54