### PR TITLE
chore: set peer persistence to false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ nim_waku_p2p_udp_port: 30303
 
 # P2P Connections
 nim_waku_p2p_max_connections: 150
+nim_waku_keep_alive: true
 nim_waku_peer_persistence: false
 
 # Store

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,8 +41,9 @@ nim_waku_disc_v5_port: 9000
 nim_waku_p2p_tcp_port: 30303
 nim_waku_p2p_udp_port: 30303
 
-# maximum libp2p connections
+# P2P Connections
 nim_waku_p2p_max_connections: 150
+nim_waku_peer_persistence: false
 
 # Store
 nim_waku_store_message_retention_policy: 'time:604800' # 7 days

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -43,7 +43,7 @@ services:
       --{{ protocol }}=true
 {% endfor %}
       --rpc-admin=true
-      --peer-persistence=true
+      --peer-persistence={{ nim_waku_peer_persistence | to_json }}
       --keep-alive=true
       --max-connections={{ nim_waku_p2p_max_connections }}
       --dns4-domain-name={{ nim_waku_dns4_domain_name }}

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -44,7 +44,7 @@ services:
 {% endfor %}
       --rpc-admin=true
       --peer-persistence={{ nim_waku_peer_persistence | to_json }}
-      --keep-alive=true
+      --keep-alive={{ nim_waku_keep_alive | to_json }}
       --max-connections={{ nim_waku_p2p_max_connections }}
       --dns4-domain-name={{ nim_waku_dns4_domain_name }}
 {% if "store" in nim_waku_protocols_enabled %}


### PR DESCRIPTION
Sets peer persistence explicitly to false for all fleets. This is not necessary anymore as DNS discovery replaces the persistent peers.

@jakubgs any chance we could stagger the rollout of this config change:
`status.test` and `wakuv2.test`
then
`wakuv2.prod`
then
`status.prod`
to verify that it works as expected before touching the prod environments?

cc @alrevuelta