### PR TITLE
refactor(topic): docker-compose.yml.j2: update the usage of 'topic' parameter

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -47,7 +47,9 @@ services:
       --keep-alive={{ nim_waku_keep_alive | to_json }}
       --max-connections={{ nim_waku_p2p_max_connections }}
       --dns4-domain-name={{ nim_waku_dns4_domain_name }}
-      --topics='{{ nim_waku_topics | join(" ") }}'
+{% for topic in nim_waku_topics %}
+      --topic='{{ topic }}'
+{% endfor %}
 {% for protected_topic in nim_waku_protected_topics %}
       --protected-topic='{{ protected_topic | mandatory }}'
 {% endfor %}


### PR DESCRIPTION
## Summary
Specifying the pubsub topics to the wakunode app through the `topic` parameter instead of the `topics` parameter.

## More context
This change is interesting due to the deprecation of the 'topics' parameter, which was done in the next PR:
https://github.com/waku-org/nwaku/pull/1727