### PR TITLE
Enabling  database vacuum by the application

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,6 +51,7 @@ nim_waku_peer_persistence: false
 
 # Store
 nim_waku_store_message_retention_policy: 'time:604800' # 7 days
+nim_waku_store_vacuum: false
 
 # RLN Relay parameters
 nim_waku_rln_relay_content_topic: '/toy-chat/2/luzhou/proto'

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -50,6 +50,7 @@ services:
       --topics='{{ nim_waku_topics | join(" ") }}'
 {% if "store" in nim_waku_protocols_enabled %}
       --store-message-db-url='sqlite:///data/store.sqlite3'
+      --store-message-db-vacuum={{ nim_waku_store_vacuum | to_json }}
       --store-message-retention-policy={{ nim_waku_store_message_retention_policy }}
 {% endif %}
 {% if "rln-relay" in nim_waku_protocols_enabled %}


### PR DESCRIPTION
The default value is false : https://docs.waku.org/guides/reference/node-config-options#store-and-message-store-config