### PR TITLE
drop content-topic and eth-account-address rln flags

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -59,11 +59,9 @@ services:
       --store-message-retention-policy={{ nim_waku_store_message_retention_policy }}
 {% endif %}
 {% if "rln-relay" in nim_waku_protocols_enabled %}
-      --rln-relay-content-topic={{ nim_waku_rln_relay_content_topic }}
       --rln-relay-dynamic={{ nim_waku_rln_relay_dynamic }}
       --rln-relay-tree-path={{ nim_waku_rln_relay_tree_path }}
 {% if nim_waku_rln_relay_dynamic %}
-      --rln-relay-eth-account-address={{ nim_waku_rln_relay_eth_account_address }}
       --rln-relay-eth-contract-address={{ nim_waku_rln_relay_eth_contract_address }}
       --rln-relay-eth-client-address={{ nim_waku_rln_relay_eth_client_address | mandatory }}
 {% endif -%}


### PR DESCRIPTION
* The 'rln-relay-content-topic' was deleted in https://github.com/waku-org/nwaku/commit/af95b5713fcdb79a4ccad79215f33fc5fb4ac4ea

* The 'rln-relay-eth-account-address' was deleted in https://github.com/waku-org/nwaku/commit/f08315cddebaf712a60a0d2296dcb12ead5c2855