### PR TITLE
consul: add protocols meta to support cabot nim-waku canary checks

### DIFF
--- a/tasks/consul.yml
+++ b/tasks/consul.yml
@@ -9,6 +9,7 @@
         tags: ['env:{{ env }}', 'stage:{{ stage }}', 'nim', 'waku', 'libp2p']
         meta:
           node_enode: '{{ nim_waku_libp2p_multiaddr | default("unknown") }}'
+          protocols: '{{ nim_waku_protocols_enabled | join(",") }}'
         checks:
           - name: '{{ nim_waku_cont_name }}-health'
             type: 'tcp'


### PR DESCRIPTION
Canary checks are updated here: https://github.com/status-im/infra-hq/pull/104