### PR TITLE
Update docker-compose.yml.j2

### DIFF
--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -110,7 +110,7 @@ services:
       --metrics-server-port={{ nim_waku_metrics_port }}
       --metrics-server-address=0.0.0.0
 {% if nim_waku_relay_shard_manager is defined %}
-      --shard-relay-manager={{ nim_waku_relay_shard_manager }}
+      --relay-shard-manager={{ nim_waku_relay_shard_manager }}
 {% endif %}
 {% if nim_waku_websockify_enabled %}
 


### PR DESCRIPTION
Fix incorrect parameter name. It should be `relay-shard-manager` according to https://github.com/waku-org/nwaku/blob/29b0c0b8da0f4af04b11997d35ff51daafd9ccce/apps/wakunode2/external_config.nim#L214