### PR TITLE
check db_url for dollar sign

### DIFF
--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -1,0 +1,6 @@
+---
+- name: Check nim_waku_store_message_db_url for $ sign
+  assert:
+    that: "{{ not nim_waku_store_message_db_url | regex_search('\\$') }}"
+    fail_msg: "Do not use $ (dollar) sign in passwords: {{ nim_waku_store_message_db_url }}"
+    quiet: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+- import_tasks: check.yml
 - import_tasks: install.yml
 - import_tasks: nodekey.yml
 - import_tasks: config.yml


### PR DESCRIPTION
Don't allow passwords like `auWn$N8k%X^Bh8Lz`.

Docker Compose substitutes variables starting with $ sign:
https://docs.docker.com/compose/compose-file/compose-file-v2/#variable-substitution