### PR TITLE
remove unused rest-private parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ REST API is avalable to inspect the node and use protocols:
 nim_waku_rest_enabled: true
 nim_waku_rest_addr: '127.0.0.1'
 nim_waku_rest_port: 8645
-nim_waku_rest_apis_enabled: ['admin', 'private']
+nim_waku_rest_apis_enabled: ['admin']
 ```
 For full docs see [API docs page](https://waku-org.github.io/waku-rest-api/).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ nim_waku_public_address: '{{ ansible_host }}'
 nim_waku_rest_enabled: true
 nim_waku_rest_addr: '127.0.0.1'
 nim_waku_rest_port: 8645
-nim_waku_rest_apis_enabled: ['admin'] # admin, private
+nim_waku_rest_apis_enabled: ['admin'] # admin
 nim_waku_websock_port: 8000
 nim_waku_disc_v5_port: 9000
 nim_waku_p2p_tcp_port: 30303

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -61,7 +61,6 @@ rest = true
 rest-address = '0.0.0.0'
 rest-port = {{ nim_waku_rest_port }}
 rest-admin = {{ ("admin" in nim_waku_rest_apis_enabled) | bool | to_json }}
-rest-private = {{ ("private" in nim_waku_rest_apis_enabled) | bool | to_json }}
 {% endif %}
 
 {% if nim_waku_websocket_enabled %}


### PR DESCRIPTION
This is needed because nwaku no longer support this parameter. 

See:
- https://github.com/waku-org/nwaku/pull/3004