### PR TITLE
sonda: add sonda tool for metrics

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,6 +122,13 @@ nim_waku_monitor_service_user: 'root'
 nim_waku_monitor_service_work_dir: '/etc/consul'
 nim_waku_monitor_script: '{{ nim_waku_cont_vol }}/monitor.sh'
 
+# Store protocol healthcheck - Sonda
+nim_waku_sonda_enabled: false
+nim_waku_sonda_cont_name: "sonda"
+nim_waku_sonda_cont_vol: '/docker/{{ nim_waku_sonda_cont_name }}'
+nim_waku_sonda_metrics_port: 8004
+nim_waku_sonda_service_name: "sonda"
+
 # Consul Service
 nim_waku_consul_config_name: '{{ nim_waku_cont_name | replace("-", "_") }}'
 nim_waku_consul_service_name: 'nim-waku'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,3 +8,5 @@
 - import_tasks: consul.yml
 - import_tasks: monitor.yml
   when: nim_waku_monitor_enabled
+- import_tasks: sonda.yml
+  when: nim_waku_sonda_enabled

--- a/tasks/sonda.yml
+++ b/tasks/sonda.yml
@@ -1,0 +1,72 @@
+---
+- name: 'Create sonda conf folder'
+  file:
+    dest: '{{ nim_waku_sonda_cont_vol }}'
+    state: 'directory'
+    owner: dockremap
+    group: docker
+    mode: 0775
+
+- name: Create Sonda compose file, dockerfile and sonda script
+  template:
+    src:   '{{ item }}.j2'
+    dest:  '{{ nim_waku_sonda_cont_vol }}/{{ item }}'
+    owner: 'dockremap'
+    group: 'docker'
+    mode:  0644
+  with_items:
+    - "docker-compose-sonda.yml"
+    - "sonda.py"
+    - "Dockerfile.sonda"
+
+# We need to fetch fleet data in order to have store nodes value with peer ID
+- name: Fetch fleet data
+  uri:
+    url: "https://fleets.status.im/"
+    method: GET
+    return_content: yes
+    status_code: 200
+  register: fleet_data
+
+- name: Parse fleet JSON and select store nodes within fleet and DC
+  set_fact:
+    sonda_store_nodes: "{{ fleet_data.json.fleets[domain_key]['tcp/p2p/waku'] | dict2items | selectattr('key', 'search', '^store') | selectattr('key', 'search', datacenter) | map(attribute='value') | join(',')  }}"
+  vars:
+    domain_key: "{{ nim_waku_dns4_domain_name.split('.')[2] + '.' + nim_waku_dns4_domain_name.split('.')[3] }}"
+    datacenter: "{{ nim_waku_dns4_domain_name.split('.')[1] }}"
+
+- name: Create Sonda environment file
+  template:
+    src:   'sonda.env.j2'
+    dest:  '{{ nim_waku_sonda_cont_vol }}/sonda.env'
+    owner: 'dockremap'
+    group: 'docker'
+    mode:  0644
+
+- name: 'Create container: {{ nim_waku_sonda_cont_name }}'
+  community.docker.docker_compose_v2:
+    project_src: '{{ nim_waku_sonda_cont_vol }}'
+    files: [ "docker-compose-sonda.yml" ]
+    build: 'always'
+    pull: 'never'
+    state: '{{ "present" }}'
+
+# The healthcheck is done on only endpoint which doesn't return metrics
+# https://prometheus.github.io/client_python/exporting/http/#supported-http-methods
+- name: Create Consul service definition
+  include_role: name=infra-role-consul-service
+  vars:
+    consul_config_name: '{{ nim_waku_sonda_service_name }}'
+    consul_services:
+      - id:      '{{ nim_waku_sonda_service_name }}'
+        name:    '{{ nim_waku_sonda_service_name }}'
+        port:    '{{ nim_waku_sonda_metrics_port }}'
+        address: '{{ ansible_local.wireguard.vpn_ip }}'
+        tags: ['sonda', 'metrics', 'nim-waku']
+        meta:
+          container: '{{ nim_waku_sonda_cont_name }}'
+        checks:
+          - id: '{{ nim_waku_sonda_service_name }}-health'
+            name: 'Sonda Service Healthcheck'
+            type: 'http'
+            http: 'http://localhost:{{ nim_waku_sonda_metrics_port }}/favicon.ico'

--- a/templates/Dockerfile.sonda.j2
+++ b/templates/Dockerfile.sonda.j2
@@ -1,0 +1,17 @@
+FROM python:3.9.18-alpine3.18
+
+ENV QUERY_DELAY=60
+ENV STORE_NODES=""
+ENV CLUSTER_ID=1
+ENV SHARD_ID=1
+ENV HEALTH_THRESHOLD=5
+
+EXPOSE {{ nim_waku_sonda_metrics_port }}
+
+WORKDIR /opt
+
+COPY sonda.py /opt/sonda.py
+
+RUN pip install requests argparse prometheus_client
+
+CMD python -u /opt/sonda.py --delay-seconds=$QUERY_DELAY --pubsub-topic=/waku/2/rs/$CLUSTER_ID/$SHARD_ID --store-nodes=$STORE_NODES --health-threshold=$HEALTH_THRESHOLD

--- a/templates/docker-compose-sonda.yml.j2
+++ b/templates/docker-compose-sonda.yml.j2
@@ -1,0 +1,16 @@
+---
+services:
+  sonda:
+    container_name: '{{ nim_waku_sonda_cont_name }}'
+    build:
+      context: .
+      dockerfile: Dockerfile.sonda
+    ports:
+      - {{ nim_waku_sonda_metrics_port }}:{{ nim_waku_sonda_metrics_port }}
+    env_file: "sonda.env"
+    networks:
+      - {{ nim_waku_cont_name }}_default
+
+networks:
+  {{ nim_waku_cont_name }}_default:
+    external: true

--- a/templates/sonda.env.j2
+++ b/templates/sonda.env.j2
@@ -1,0 +1,8 @@
+CLUSTER_ID: {{ nim_waku_cluster_id }}
+SHARD: {{ nim_waku_pubsub_topics[0].split('/')[-1] }}
+# Comma separated list of store nodes to poll
+STORE_NODES: "{{ sonda_store_nodes }}"
+# Wait time in seconds between two consecutive queries
+QUERY_DELAY: 60
+# Consecutive successful store requests to consider a store node healthy
+HEALTH_THRESHOLD: 5

--- a/templates/sonda.py.j2
+++ b/templates/sonda.py.j2
@@ -1,0 +1,206 @@
+import requests
+import time
+import json
+import os
+import base64
+import sys
+import urllib.parse
+import requests
+import argparse
+from datetime import datetime
+from prometheus_client import Counter, Gauge, start_http_server
+
+# Content topic where Sona messages are going to be sent
+SONDA_CONTENT_TOPIC = '/sonda/2/polls/proto'
+
+# Prometheus metrics
+successful_sonda_msgs = Counter('successful_sonda_msgs', 'Number of successful Sonda messages sent')
+failed_sonda_msgs = Counter('failed_sonda_msgs', 'Number of failed Sonda messages attempts')
+successful_store_queries = Counter('successful_store_queries', 'Number of successful store queries', ['node'])
+failed_store_queries = Counter('failed_store_queries', 'Number of failed store queries', ['node', 'error'])
+empty_store_responses = Counter('empty_store_responses', "Number of store responses without the latest Sonda message", ['node'])
+store_query_latency = Gauge('store_query_latency', 'Latency of the last store query in seconds', ['node'])
+consecutive_successful_responses = Gauge('consecutive_successful_responses', 'Consecutive successful store responses', ['node'])
+node_health = Gauge('node_health', "Binary indicator of a node's health. 1 is healthy, 0 is not", ['node'])
+
+
+# Argparser configuration
+parser = argparse.ArgumentParser(description='')
+parser.add_argument('-p', '--pubsub-topic', type=str, help='pubsub topic', default='/waku/2/rs/1/0')
+parser.add_argument('-d', '--delay-seconds', type=int, help='delay in second between messages', default=60)
+parser.add_argument('-n', '--store-nodes', type=str, help='comma separated list of store nodes to query', required=True)
+parser.add_argument('-t', '--health-threshold', type=int, help='consecutive successful store requests to consider a store node healthy', default=5)
+args = parser.parse_args()
+
+
+# Logs message including current UTC time
+def log_with_utc(message):
+    utc_time = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{utc_time} UTC] {message}")
+
+
+# Sends Sonda message. Returns True if successful, False otherwise
+def send_sonda_msg(rest_address, pubsub_topic, content_topic, timestamp):
+    message = "Hi, I'm Sonda"
+    base64_message = base64.b64encode(message.encode('utf-8')).decode('ascii')
+    body = {
+        'payload': base64_message,
+        'contentTopic': content_topic,
+        'version': 1,
+        'timestamp': timestamp
+    }
+
+    encoded_pubsub_topic = urllib.parse.quote(pubsub_topic, safe='')
+    url = f'{rest_address}/relay/v1/messages/{encoded_pubsub_topic}'
+    headers = {'content-type': 'application/json'}
+
+    log_with_utc(f'Sending Sonda message via REST: {url} PubSubTopic: {pubsub_topic}, ContentTopic: {content_topic}, timestamp: {timestamp}')
+    
+    try:
+        start_time = time.time()
+        response = requests.post(url, json=body, headers=headers, timeout=10)
+        elapsed_seconds = time.time() - start_time
+        
+        log_with_utc(f'Response from {rest_address}: status:{response.status_code} content:{response.text} [{elapsed_seconds:.4f} s.]')
+        
+        if response.status_code == 200:
+            successful_sonda_msgs.inc()
+            return True
+        else:
+            response.raise_for_status()
+    except requests.RequestException as e:
+        log_with_utc(f'Error sending request: {e}')
+    
+    failed_sonda_msgs.inc()
+    return False
+
+
+# We return true if both our node and the queried Store node returned a 200
+# If our message isn't found but we did get a store 200 response, this function still returns true
+def check_store_response(json_response, store_node, timestamp):
+  # Check for the store node status code
+  if json_response.get('statusCode') != 200:
+    error = f"{json_response.get('statusCode')} {json_response.get('statusDesc')}"
+    log_with_utc(f'Failed performing store query {error}')
+    failed_store_queries.labels(node=store_node, error=error).inc()
+    consecutive_successful_responses.labels(node=store_node).set(0)
+    
+    return False
+  
+  messages = json_response.get('messages')
+  # If there's no message in the response, increase counters and return
+  if not messages:
+    log_with_utc("No messages in store response")
+    empty_store_responses.labels(node=store_node).inc()
+    consecutive_successful_responses.labels(node=store_node).set(0)
+    return True
+
+  # Search for the Sonda message in the returned messages
+  for message in messages:
+    # If message field is missing in current message, continue
+    if not message.get("message"):
+      log_with_utc("Could not retrieve message")
+      continue
+    
+    # If a message is found with the same timestamp as sonda message, increase counters and return
+    if timestamp == message.get('message').get('timestamp'):
+      log_with_utc(f'Found Sonda message in store response node={store_node}')
+      successful_store_queries.labels(node=store_node).inc()
+      consecutive_successful_responses.labels(node=store_node).inc()
+      return True
+
+  # If our message wasn't found in the returned messages, increase counter and return
+  empty_store_responses.labels(node=store_node).inc()
+  consecutive_successful_responses.labels(node=store_node).set(0)
+  return True
+
+
+def send_store_query(rest_address, store_node, encoded_pubsub_topic, encoded_content_topic, timestamp):
+    url = f'{rest_address}/store/v3/messages'
+    params = {
+        'peerAddr': urllib.parse.quote(store_node, safe=''), 
+        'pubsubTopic': encoded_pubsub_topic,
+        'contentTopics': encoded_content_topic, 
+        'includeData': 'true', 
+        'startTime': timestamp
+    }
+    
+    s_time = time.time()
+    
+    try:
+        log_with_utc(f'Sending store request to {store_node}')
+        response = requests.get(url, params=params)
+    except Exception as e:
+      log_with_utc(f'Error sending request: {e}')
+      failed_store_queries.labels(node=store_node, error=str(e)).inc()
+      consecutive_successful_responses.labels(node=store_node).set(0)
+      return False
+
+    elapsed_seconds = time.time() - s_time
+    log_with_utc(f'Response from {rest_address}: status:{response.status_code} [{elapsed_seconds:.4f} s.]')
+
+    if response.status_code != 200:
+        failed_store_queries.labels(node=store_node, error=f'{response.status_code} {response.content}').inc()
+        consecutive_successful_responses.labels(node=store_node).set(0)
+        return False
+
+    # Parse REST response into JSON
+    try:
+        json_response = response.json()
+    except Exception as e:
+        log_with_utc(f'Error parsing response JSON: {e}')
+        failed_store_queries.labels(node=store_node, error="JSON parse error").inc()
+        consecutive_successful_responses.labels(node=store_node).set(0)
+        return False
+
+    # Analyze Store response. Return false if response is incorrect or has an error status
+    if not check_store_response(json_response, store_node, timestamp):
+        return False
+
+    store_query_latency.labels(node=store_node).set(elapsed_seconds)
+    return True
+
+
+def send_store_queries(rest_address, store_nodes, pubsub_topic, content_topic, timestamp):
+    log_with_utc(f'Sending store queries. nodes = {store_nodes} timestamp = {timestamp}')
+    encoded_pubsub_topic = urllib.parse.quote(pubsub_topic, safe='')
+    encoded_content_topic = urllib.parse.quote(content_topic, safe='')
+    
+    for node in store_nodes:
+      send_store_query(rest_address, node, encoded_pubsub_topic, encoded_content_topic, timestamp)
+
+
+def main():
+  log_with_utc(f'Running Sonda with args={args}')
+
+  store_nodes = []
+  if args.store_nodes is not None:
+      store_nodes = [s.strip() for s in args.store_nodes.split(",")]
+  log_with_utc(f'Store nodes to query: {store_nodes}')
+
+  # Start Prometheus HTTP server at port {{ nim_waku_sonda_metrics_port }}
+  start_http_server({{ nim_waku_sonda_metrics_port }})
+
+  node_rest_address = 'http://{{ nim_waku_cont_name }}:{{ nim_waku_rest_port }}'
+  while True:
+    timestamp = time.time_ns()
+      
+    # Send Sonda message
+    res = send_sonda_msg(node_rest_address, args.pubsub_topic, SONDA_CONTENT_TOPIC, timestamp)
+
+    log_with_utc(f'sleeping: {args.delay_seconds} seconds')
+    time.sleep(args.delay_seconds)
+
+    # Only send store query if message was successfully published
+    if(res):
+      send_store_queries(node_rest_address, store_nodes, args.pubsub_topic, SONDA_CONTENT_TOPIC, timestamp)
+    
+    # Update node health metrics
+    for store_node in store_nodes:
+      if consecutive_successful_responses.labels(node=store_node)._value.get() >= args.health_threshold:
+        node_health.labels(node=store_node).set(1)
+      else:
+        node_health.labels(node=store_node).set(0)
+
+
+main()


### PR DESCRIPTION
The tool should only be installed on boot nodes, but this can be controlled with nim_waku_sonda_enabled flag set from the calling playbook.

Referenced issue: https://github.com/status-im/infra-hq/issues/135