### PR TITLE
chore: using protected shards instead of topics

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,8 +28,8 @@ nim_waku_protocols_enabled: ['relay', 'store', 'filter', 'lightpush']
 
 # Topic configuration
 nim_waku_pubsub_topics: ['/waku/2/default-waku/proto']
-# Topics and its public key to be used for message validation.
-nim_waku_protected_topics: []
+# Shards and its public key to be used for message validation.
+nim_waku_protected_shards: []
 
 # Available: error, warn, info, debug
 nim_waku_log_level: 'info'

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -37,9 +37,9 @@ pubsub-topic = [
   '{{ topic }}',
 {% endfor %}
 ]
-protected-topic = [
-{% for topic in nim_waku_protected_topics %}
-  '{{ topic }}',
+protected-shard = [
+{% for shard in nim_waku_protected_shards %}
+  '{{ shard }}',
 {% endfor %}
 ]
 


### PR DESCRIPTION
Initial PR to replace the deprecated `protected-topic` flag for the newer `protected-shard` one

After this is merged, will open PRs in the `infra-status` and `infra-waku` repos