### PR TITLE
add nim_waku_shards attribute

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,8 @@ nim_waku_protocols_available: ['relay', 'store', 'filter', 'lightpush', 'rln-rel
 nim_waku_protocols_enabled: ['relay', 'store', 'filter', 'lightpush']
 
 # Topic configuration
-nim_waku_pubsub_topics: ['/waku/2/default-waku/proto']
+nim_waku_shards: [0, 1, 2, 3, 4, 5, 6, 7]
+
 # Shards and its public key to be used for message validation.
 nim_waku_protected_shards: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,10 @@ nim_waku_protocols_available: ['relay', 'store', 'filter', 'lightpush', 'rln-rel
 nim_waku_protocols_enabled: ['relay', 'store', 'filter', 'lightpush']
 
 # Topic configuration
+# 'nim_waku_pubsub_topics' is deprecated in favor of 'nim_waku_shards'
 nim_waku_pubsub_topics: ['/waku/2/default-waku/proto']
+nim_waku_shards: [0, 1, 2, 3, 4, 5, 6, 7]
+
 # Shards and its public key to be used for message validation.
 nim_waku_protected_shards: []
 

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -32,9 +32,17 @@ cluster-id = {{ nim_waku_cluster_id }}
 {% if nim_waku_relay_shard_manager is defined %}
 relay-shard-manager = {{ nim_waku_relay_shard_manager | to_json }}
 {% endif %}
+
+# pubsub-topic is deprecated and we need to remove the next once we
+# make sure the nodes run well with shard's param
 pubsub-topic = [
 {% for topic in nim_waku_pubsub_topics %}
   '{{ topic }}',
+{% endfor %}
+]
+shard = [
+{% for nws in nim_waku_shards %}
+  {{ nws }},
 {% endfor %}
 ]
 protected-shard = [

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -25,16 +25,16 @@ max-msg-size = '{{ nim_waku_max_msg_size }}'
 ip-colocation-limit = {{ nim_waku_ip_colocation_limit }}
 {% endif %}
 
-### Topics
+### Cluster id and shards
 {% if nim_waku_cluster_id is defined %}
 cluster-id = {{ nim_waku_cluster_id }}
 {% endif %}
 {% if nim_waku_relay_shard_manager is defined %}
 relay-shard-manager = {{ nim_waku_relay_shard_manager | to_json }}
 {% endif %}
-pubsub-topic = [
-{% for topic in nim_waku_pubsub_topics %}
-  '{{ topic }}',
+shard = [
+{% for nws in nim_waku_shards %}
+  {{ nws }},
 {% endfor %}
 ]
 protected-shard = [


### PR DESCRIPTION
We are in the process of deprecating pubsub-topic param from nim-waku. The pubsub-topic shouldn't be used to start nim-waku and instead, a combination of 1 cluster-id plus n shard should be given. This aims to start using the new added param: shard.

Completely remove the pubsub-topic config params.