### PR TITLE
config: add support for multiple RLN eth client URLs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,7 +77,9 @@ nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 nim_waku_rln_relay_dynamic: true
 nim_waku_rln_relay_eth_account_address: '0000000000000000000000000000000000000000'
 nim_waku_rln_relay_eth_contract_address: '0xF471d71E9b1455bBF4b85d475afb9BB0954A29c4'
-#nim_waku_rln_relay_eth_client_address: 'http://geth.example.org:8545'
+# TODO: switch to list completele after all nodes are v0.36.0+
+#nim_waku_rln_relay_eth_client_address: 'http://geth.example.org:8545' # < v0.36.0
+#nim_waku_rln_relay_eth_client_address: ['http://geth.example.org:8545'] # >= v0.36.0
 #nim_waku_relay_shard_manager: false
 # RLN Keystore parameters
 nim_waku_node_keystore_path: '{{ nim_waku_node_db_path }}/keystore'

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -13,7 +13,7 @@ dns4-domain-name = '{{ nim_waku_dns4_domain_name }}'
 nat = 'extip:{{ nim_waku_public_address }}'
 log-level = '{{ nim_waku_log_level | upper }}'
 
-### Nework
+### Network
 peer-persistence = {{ nim_waku_peer_persistence | to_json }}
 keep-alive = {{ nim_waku_keep_alive | to_json }}
 max-connections = {{ nim_waku_p2p_max_connections }}
@@ -93,7 +93,15 @@ rln-relay-dynamic = {{ nim_waku_rln_relay_dynamic | to_json }}
 rln-relay-tree-path = '{{ nim_waku_rln_relay_tree_path }}'
 {% if nim_waku_rln_relay_dynamic %}
 rln-relay-eth-contract-address = '{{ nim_waku_rln_relay_eth_contract_address }}'
+{% if nim_waku_rln_relay_eth_client_address is string %}
 rln-relay-eth-client-address = '{{ nim_waku_rln_relay_eth_client_address | mandatory }}'
+{% else %}
+rln-relay-eth-client-address = [
+{% for address in nim_waku_rln_relay_eth_client_address %}
+  '{{ address }}'
+{% endfor %}
+]
+{% endif %}
 {% endif %}
 {% if nim_waku_rln_keystore_active %}
 rln-relay-cred-path = '{{ nim_waku_rln_keystore_path }}'

--- a/templates/entrypoint.sh.j2
+++ b/templates/entrypoint.sh.j2
@@ -9,7 +9,13 @@ else
   ## Performs the RLN registration if the keystore.json credentials file does not exist
   mkdir -p $(dirname {{ nim_waku_rln_keystore_path }})
   exec /usr/bin/wakunode generateRlnKeystore \
-      --rln-relay-eth-client-address={{ nim_waku_rln_relay_eth_client_address }} \
+{% if nim_waku_rln_relay_eth_client_address is string %}
+      --rln-relay-eth-client-address='{{ nim_waku_rln_relay_eth_client_address }}' \
+{% else %}
+{% for address in nim_waku_rln_relay_eth_client_address %}
+      --rln-relay-eth-client-address={{ address }} \
+{% endfor %}
+{% endif %}
       --rln-relay-eth-private-key={{ nim_waku_rln_account_key | mandatory }} \
       --rln-relay-eth-contract-address={{nim_waku_rln_relay_eth_contract_address}} \
       --rln-relay-cred-path='{{ nim_waku_rln_keystore_path }}' \


### PR DESCRIPTION
Versions before 0.36.0 take one argument, while versions since 0.36.0 support supplying multiple addresses.

Required after the following has been implemented:
- https://github.com/waku-org/nwaku/pull/3402

---
Notice that we don't need to change the logic when passing CLI parameters because by repeating the same "`--param`" we just get an array internally. But, when dealing with params from a `.toml` file, then we need to explicitly pass them as an array. Thus this PR is submitted :).
