### PR TITLE
consul: add cluster-id and shards to metadata

### DIFF
--- a/tasks/consul.yml
+++ b/tasks/consul.yml
@@ -14,6 +14,8 @@
           enr:        '{{ nim_waku_libp2p_enr_uri      | default("unknown") }}'
           multiaddr:  '{{ nim_waku_libp2p_multiaddr    | default("unknown") }}'
           websocket:  '{{ nim_waku_websocket_multiaddr | default("missing") }}'
+          cluster-id: '{{ nim_waku_cluster_id          | default("missing") }}'
+          shards:     '{{ nim_waku_shards              | join(",") | default("missing") }}'
           image:      '{{ nim_waku_cont_image }}'
           commit:     '{{ nim_waku_cont.container.Config.Labels.commit  | default("unknown") }}'
           version:    '{{ nim_waku_cont.container.Config.Labels.version | default("unknown") }}'


### PR DESCRIPTION
We are already setting this in ansible roles: 
- https://github.com/status-im/infra-status/blob/master/ansible/group_vars/boot.yml#L23-29
- https://github.com/status-im/infra-waku/blob/master/ansible/group_vars/node.yml

so we are just adding it to a consul metadata so we can extract
it later and setup Kuma checks based on Consul fleet data.

- https://github.com/waku-org/nwaku/pull/3415
- https://github.com/status-im/infra-hq/pull/217