### PR TITLE
defaults: add legacy-store to available protocols

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,7 @@ nim_waku_node_key_file_path: '{{ nim_waku_cont_vol }}/nodekey'
 #nim_waku_cluster_id: 1
 
 # Protocols
-nim_waku_protocols_available: ['relay', 'store', 'filter', 'lightpush', 'rln-relay', 'peer-exchange', 'store-sync']
+nim_waku_protocols_available: ['relay', 'store', 'filter', 'lightpush', 'rln-relay', 'peer-exchange', 'store-sync', 'legacy-store']
 nim_waku_protocols_enabled: ['relay', 'store', 'filter', 'lightpush']
 
 # Topic configuration


### PR DESCRIPTION
In https://github.com/waku-org/nwaku/pull/3484 we're setting `legacy-store` to false by default, so we need to be able to turn set it to `true` in the status fleets, which still use that protocol