### PR TITLE
config: drop max-relay-peers for relay-service-ratio

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ nim_waku_p2p_udp_port: 30303
 
 # P2P Connections
 nim_waku_p2p_max_connections: 150
-nim_waku_max_relay_peers: '{{ nim_waku_p2p_max_connections }}'
+nim_waku_relay_service_ratio: '50:50'
 nim_waku_keep_alive: true
 nim_waku_peer_persistence: false
 #nim_waku_ip_colocation_limit: 2

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -19,7 +19,7 @@ peer-persistence = {{ nim_waku_peer_persistence | to_json }}
 keep-alive = true
 {% endif %}
 max-connections = {{ nim_waku_p2p_max_connections }}
-max-relay-peers = {{ nim_waku_max_relay_peers }}
+relay-service-ratio = '{{ nim_waku_relay_service_ratio }}'
 {% if nim_waku_max_msg_size is defined %}
 max-msg-size = '{{ nim_waku_max_msg_size }}'
 {% endif %}


### PR DESCRIPTION
The `max-relay-peers` config option was removed in nwaku v0.38.
Replace it with the new `relay-service-ratio` option (default 50:50).

Fixes repeated "Unexpected field 'max-relay-peers'" errors on waku.test fleet.

Note :- 
we deprecate `max-relay-peers` few month ago seems infra is missing that update. 

[kibana link](https://kibana.infra.status.im/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1500m,to:now))&_a=(columns:!(),filters:!(),hideChart:!f,index:ffcc22b0-0116-11ed-9719-cdd3b483481c,interval:auto,query:(language:kuery,query:'message:%22%20Failed%20to%20load%20secondary%20sources%22'),sort:!(!('@timestamp',desc))))

<img width="2296" height="1140" alt="Screenshot 2026-02-16 at 12 32 02" src="https://github.com/user-attachments/assets/3e45dadb-b7f1-46e0-981e-c55f08bf30b2" />

