### PR TITLE
config: increase rln-relay-user-message-limit to 300

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ nim_waku_store_message_db_url: 'sqlite:///data/store.sqlite3'
 nim_waku_rln_relay_tree_path: '/data/rln_relay_tree'
 nim_waku_rln_relay_dynamic: true
 nim_waku_rln_relay_eth_contract_address: '0xB9cd878C90E49F797B4431fBF4fb333108CB90e6'
+nin_waku_rln_relay_user_mesage_limit: 100
 # TODO: switch to list completele after all nodes are v0.36.0+
 #nim_waku_rln_relay_eth_client_address: 'http://geth.example.org:8545' # < v0.36.0
 #nim_waku_rln_relay_eth_client_address: ['http://geth.example.org:8545'] # >= v0.36.0

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -99,6 +99,7 @@ rln-relay-eth-contract-address = '{{ nim_waku_rln_relay_eth_contract_address }}'
 {% if nim_waku_rln_keystore_active %}
 rln-relay-cred-path = '{{ nim_waku_rln_keystore_path }}'
 {% endif %}
+rln-relay-user-message-limit = {{ nin_waku_rln_relay_user_mesage_limit }}
 {% endif %}
 
 {% if "store-sync" in nim_waku_protocols_enabled %}

--- a/templates/entrypoint.sh.j2
+++ b/templates/entrypoint.sh.j2
@@ -21,7 +21,7 @@ else
       --rln-relay-eth-contract-address={{nim_waku_rln_relay_eth_contract_address}} \
       --rln-relay-cred-path='{{ nim_waku_rln_keystore_path }}' \
       --rln-relay-cred-password='{{ nim_waku_rln_cred_password | mandatory }}' \
-      --rln-relay-user-message-limit=100 \
+      --rln-relay-user-message-limit={{ nin_waku_rln_relay_user_mesage_limit }} \
      --execute
 fi
 {% endif %}


### PR DESCRIPTION
Railgun's broadcaster requires a higher RLN message limit for its operations.
we increase the `rln-relay-user-message-limit` on our fleets from 100 to 300 to ensure better stability for Railgun and Status.

