### PR TITLE
consul: add cluster-id and shards to websocket service metadata

### DIFF
--- a/tasks/consul.yml
+++ b/tasks/consul.yml
@@ -80,6 +80,8 @@
           node_enode: '{{ nim_waku_websocket_multiaddr }}'
           protocols:  '{{ nim_waku_protocols_enabled | join(",") }}'
           image:      '{{ nim_waku_cont_image }}'
+          cluster-id: '{{ nim_waku_cluster_id          | default("missing") }}'
+          shards:     '{{ nim_waku_shards              | join(",") | default("missing") }}'
           commit:     '{{ nim_waku_cont.container.Config.Labels.commit  | default("unknown") }}'
           version:    '{{ nim_waku_cont.container.Config.Labels.version | default("unknown") }}'
         checks:


### PR DESCRIPTION
- Align websocket service meta with libp2p service
- Enables wakucanary to perform full peer connectivity check including ping

Issue:
- https://github.com/status-im/infra-hq/issues/266